### PR TITLE
fix json flaky test

### DIFF
--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
@@ -27,7 +27,9 @@ import java.util.Map;
 
 import org.testng.annotations.Test;
 
-import com.google.gson.*;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.ibm.cloud.sdk.core.http.HttpMediaType;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.test.TestUtils;
@@ -232,7 +234,6 @@ public class RequestBuilderTest {
     final RequestBody requestedBody = request.body();
     final Buffer buffer = new Buffer();
     requestedBody.writeTo(buffer);
-    
     JsonElement listOfModelsToJson = JsonParser.parseString(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(listOfModels));
     JsonElement bufferToJson = JsonParser.parseString(buffer.readUtf8());
 

--- a/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
+++ b/src/test/java/com/ibm/cloud/sdk/core/test/service/RequestBuilderTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import org.testng.annotations.Test;
 
-import com.google.gson.JsonObject;
+import com.google.gson.*;
 import com.ibm.cloud.sdk.core.http.HttpMediaType;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.test.TestUtils;
@@ -232,8 +232,11 @@ public class RequestBuilderTest {
     final RequestBody requestedBody = request.body();
     final Buffer buffer = new Buffer();
     requestedBody.writeTo(buffer);
+    
+    JsonElement listOfModelsToJson = JsonParser.parseString(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(listOfModels));
+    JsonElement bufferToJson = JsonParser.parseString(buffer.readUtf8());
 
-    assertEquals(GsonSingleton.getGsonWithoutPrettyPrinting().toJson(listOfModels), buffer.readUtf8());
+    assertEquals(listOfModelsToJson, bufferToJson);
     assertEquals(HttpMediaType.JSON, requestedBody.contentType());
   }
 


### PR DESCRIPTION
The test com.ibm.cloud.sdk.core.test.service.RequestBuilderTest.testBodyContentList compares a string serialized from a List with the content of the RequestBody built by the List. However, serializing a list of Vehicle objects did not return the deterministic string. 
Flaky test before thie PR:

[[{"engine_type":"raptor","vehicle_type":"Truck","make":"Ford"},{"body_style":"mach-e","vehicle_type":"Car","make":"Ford"}]] but found [[{"engine_type":"raptor","make":"Ford","vehicle_type":"Truck"},{"body_style":"mache","vehicle_type":"Car","make":"Ford"}]]

This PR proposes to parse the content of request body to json and parser the Vehicle list to json, then compare them to get the result.


